### PR TITLE
Make it work for other post types

### DIFF
--- a/menu-recent-pages.php
+++ b/menu-recent-pages.php
@@ -23,7 +23,7 @@ function mrp_add_wp_admin_style() {
 
 add_action( 'admin_footer', 'mrp_add_recent_pages' );
 function mrp_add_recent_pages() {
-    GLOBAL $wpdb;
+    global $wpdb;
 
 	$post_types = get_post_types( array(
 		'show_ui' => true
@@ -51,7 +51,7 @@ function mrp_add_recent_pages() {
 			LIMIT %d
 		", $post_type, $no_of_pages );
 
-	    $page_list = (array) $wpdb->get_results($sql);
+	    $page_list = (array) $wpdb->get_results( $sql );
 
 	    if ( empty( $page_list ) )
 	    	continue;
@@ -62,15 +62,15 @@ function mrp_add_recent_pages() {
 		    $time_since = strtotime( $page->post_modified );
 	    	$time_since = human_time_diff( $time_since, time() );
 	    	$ago = sprintf( __( 'Updated about %s ago', 'menu-recent-pages' ), $time_since );
-			$append .= '<li class="mrp-recent-page"><a title="' . esc_attr( $ago ) . '" href="' . admin_url( "post.php?post={$page->ID}&action=edit" ) . '">' . esc_html( $page->post_title ) . '</a></li>';
+			$append .= '<li class="mrp-recent-page"><a title="' . esc_attr( $ago ) . '" href="' . get_edit_post_link( $page->ID ) . '">' . esc_html( $page->post_title ) . '</a></li>';
 		}
 
 	    ?>
-			<script type="text/javascript">
-				(function($) {
-					$( '#menu-<?php echo esc_attr( $slug ); ?> .wp-submenu' ).append( '<?php echo $append; ?>' );
-				})(jQuery);
-			</script>
+		<script type="text/javascript">
+			(function($) {
+				$( '#menu-<?php echo esc_attr( $slug ); ?> .wp-submenu' ).append( '<?php echo $append; ?>' );
+			})(jQuery);
+		</script>
 		<?php
 
 	}
@@ -78,7 +78,6 @@ function mrp_add_recent_pages() {
 
 function mrp_add_support() {
 	add_post_type_support( 'page', 'recent_menu' );
-	add_post_type_support( 'post', 'recent_menu' );
 }
 
 add_action( 'init', 'mrp_add_support' );

--- a/menu-recent-pages.php
+++ b/menu-recent-pages.php
@@ -54,29 +54,28 @@ function mrp_add_recent_pages() {
 	    if ( empty( $page_list ) )
 	    	continue;
 
+	    $append = '<li class="mrp-recent-pages-header">Recently Updated</li>';
+
+		foreach ($page_list as $page) {
+		    $time_since = strtotime( $page->post_modified );
+	    	$time_since = human_time_diff( $time_since, time() );
+			$append .= '<li class="mrp-recent-page"><a title="Updated about ' . $time_since . ' ago" href="' . admin_url( "post.php?post={$page->ID}&action=edit" ) . '">' . esc_html( $page->post_title ) . '</a></li>';
+		}
+
 	    ?>
 			<script type="text/javascript">
 				(function($) {
-					$( '#menu-<?php echo esc_attr( $slug ); ?> .wp-submenu' ).append('<li class="mrp-recent-pages-header">Recently Updated</li>');
+					$( '#menu-<?php echo esc_attr( $slug ); ?> .wp-submenu' ).append( '<?php echo $append; ?>' );
 				})(jQuery);
 			</script>
 		<?php
 
-		foreach ($page_list as $page) {
-		    $time_since = strtotime( $page->post_modified );
-	    	$time_since = human_time_diff( $time_since, time() ); ?>
-			<script type="text/javascript">
-				(function($) {
-					$( '#menu-<?php echo esc_attr( $slug ); ?> .wp-submenu' ).append('<li class="mrp-recent-page"><a title="Updated about <?php echo $time_since; ?> ago" href="<?php echo admin_url( "post.php?post={$page->ID}&action=edit" ); ?>"><?php echo esc_html( $page->post_title ); ?></a></li>');
-				})(jQuery);
-			</script>
-		<?php
-		}
 	}
 }
 
 function mrp_add_support() {
 	add_post_type_support( 'page', 'recent_menu' );
+	add_post_type_support( 'post', 'recent_menu' );
 }
 
 add_action( 'init', 'mrp_add_support' );

--- a/menu-recent-pages.php
+++ b/menu-recent-pages.php
@@ -30,48 +30,48 @@ function mrp_add_recent_pages() {
 	$no_of_pages = 5;
 
 	foreach ( $post_types as $post_type => $pto ) {
-	if ( ! post_type_supports( $post_type, 'recent_menu' ) )
-		continue;
+		if ( ! post_type_supports( $post_type, 'recent_menu' ) )
+			continue;
 
-	if ( 'page' == $post_type )
-		$slug = 'pages';
-	else if ( 'post' == $post_type )
-		$slug = 'posts';
-	else
-		$slug = sprintf( 'posts-%s', $post_type );
+		if ( 'page' == $post_type )
+			$slug = 'pages';
+		else if ( 'post' == $post_type )
+			$slug = 'posts';
+		else
+			$slug = sprintf( 'posts-%s', $post_type );
 
-    $sql = $wpdb->prepare( "
-		SELECT ID, post_title, post_modified
-		FROM {$wpdb->posts}
-		WHERE post_status = 'publish'
-		AND post_type = %s
-		ORDER BY post_modified DESC
-		LIMIT %d
-	", $post_type, $no_of_pages );
+	    $sql = $wpdb->prepare( "
+			SELECT ID, post_title, post_modified
+			FROM {$wpdb->posts}
+			WHERE post_status = 'publish'
+			AND post_type = %s
+			ORDER BY post_modified DESC
+			LIMIT %d
+		", $post_type, $no_of_pages );
 
-    $page_list = (array) $wpdb->get_results($sql);
+	    $page_list = (array) $wpdb->get_results($sql);
 
-    if ( empty( $page_list ) )
-    	continue;
+	    if ( empty( $page_list ) )
+	    	continue;
 
-    ?>
-		<script type="text/javascript">
-			(function($) {
-				$( '#menu-<?php echo esc_attr( $slug ); ?> .wp-submenu' ).append('<li class="mrp-recent-pages-header">Recently Updated</li>');
-			})(jQuery);
-		</script>
-	<?php
+	    ?>
+			<script type="text/javascript">
+				(function($) {
+					$( '#menu-<?php echo esc_attr( $slug ); ?> .wp-submenu' ).append('<li class="mrp-recent-pages-header">Recently Updated</li>');
+				})(jQuery);
+			</script>
+		<?php
 
-	foreach ($page_list as $page) {
-	    $time_since = strtotime( $page->post_modified );
-    	$time_since = human_time_diff( $time_since, time() ); ?>
-		<script type="text/javascript">
-			(function($) {
-				$( '#menu-<?php echo esc_attr( $slug ); ?> .wp-submenu' ).append('<li class="mrp-recent-page"><a title="Updated about <?php echo $time_since; ?> ago" href="<?php echo admin_url( "post.php?post={$page->ID}&action=edit" ); ?>"><?php echo esc_html( $page->post_title ); ?></a></li>');
-			})(jQuery);
-		</script>
-	<?php
-	}
+		foreach ($page_list as $page) {
+		    $time_since = strtotime( $page->post_modified );
+	    	$time_since = human_time_diff( $time_since, time() ); ?>
+			<script type="text/javascript">
+				(function($) {
+					$( '#menu-<?php echo esc_attr( $slug ); ?> .wp-submenu' ).append('<li class="mrp-recent-page"><a title="Updated about <?php echo $time_since; ?> ago" href="<?php echo admin_url( "post.php?post={$page->ID}&action=edit" ); ?>"><?php echo esc_html( $page->post_title ); ?></a></li>');
+				})(jQuery);
+			</script>
+		<?php
+		}
 	}
 }
 

--- a/menu-recent-pages.php
+++ b/menu-recent-pages.php
@@ -8,6 +8,8 @@ Author: Shaun Andrews
 Author URI: http://automattic.com
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: menu-recent-pages
+Domain Path: /languages/
 
 Kudos: Based on code from Ehsanul Haque's (http://ehsanIs.me/) plugin, Recently Updated Pages (http://wordpress.org/plugins/recently-updated-pages/).
 
@@ -54,12 +56,13 @@ function mrp_add_recent_pages() {
 	    if ( empty( $page_list ) )
 	    	continue;
 
-	    $append = '<li class="mrp-recent-pages-header">Recently Updated</li>';
+	    $append = '<li class="mrp-recent-pages-header">' . __( 'Recently Updated', 'menu-recent-pages' ) . '</li>';
 
 		foreach ($page_list as $page) {
 		    $time_since = strtotime( $page->post_modified );
 	    	$time_since = human_time_diff( $time_since, time() );
-			$append .= '<li class="mrp-recent-page"><a title="Updated about ' . $time_since . ' ago" href="' . admin_url( "post.php?post={$page->ID}&action=edit" ) . '">' . esc_html( $page->post_title ) . '</a></li>';
+	    	$ago = sprintf( __( 'Updated about %s ago', 'menu-recent-pages' ), $time_since );
+			$append .= '<li class="mrp-recent-page"><a title="' . esc_attr( $ago ) . '" href="' . admin_url( "post.php?post={$page->ID}&action=edit" ) . '">' . esc_html( $page->post_title ) . '</a></li>';
 		}
 
 	    ?>


### PR DESCRIPTION
I've made some alterations to the plugin so it now works on a post type support basis. Example:

`add_post_type_support( 'post', 'recent_menu' );`

Bam, the menu will be shown on Posts. Works for any post type, and of course includes Pages by default.

Also done a few bits of tidying up. Let me know what you think.
